### PR TITLE
Add Svelte 5 support via /svelte subpath export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /wasm/rust/pkg
 /wasm/rust/target
 examples-dist/
+.svelte-kit/
 
 # Logs
 logs

--- a/bun.lock
+++ b/bun.lock
@@ -1,22 +1,30 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "warper",
       "devDependencies": {
-        "@types/react": "^18.2.66",
-        "@types/react-dom": "^18.2.22",
-        "@vitejs/plugin-react": "^4.2.1",
-        "typescript": "^5.2.2",
-        "vite": "^5.2.0",
+        "@sveltejs/package": "^2.3.7",
+        "@types/react": "^18.2.66 || ^19.0.0",
+        "@types/react-dom": "^18.2.22 || ^19.0.0",
+        "@vitejs/plugin-react": "^4.3.4",
+        "svelte": "^5.29.0",
+        "svelte2tsx": "^0.7.0",
+        "typescript": "^5.7.3",
+        "vite": "^6.1.0",
         "vite-plugin-top-level-await": "^1.5.0",
         "vite-plugin-wasm": "^3.5.0",
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "svelte": "^5.29.0",
       },
+      "optionalPeers": [
+        "react",
+        "react-dom",
+        "svelte",
+      ],
     },
   },
   "packages": {
@@ -60,53 +68,61 @@
 
     "@babel/types": ["@babel/types@7.28.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.12", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
@@ -158,6 +174,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.44.2", "", { "os": "win32", "cpu": "x64" }, "sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA=="],
 
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
+
+    "@sveltejs/package": ["@sveltejs/package@2.5.7", "", { "dependencies": { "chokidar": "^5.0.0", "kleur": "^4.1.5", "sade": "^1.8.1", "semver": "^7.5.4", "svelte2tsx": "~0.7.33" }, "peerDependencies": { "svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1" }, "bin": { "svelte-package": "svelte-package.js" } }, "sha512-qqD9xa9H7TDiGFrF6rz7AirOR8k15qDK/9i4MIE8te4vWsv5GEogPks61rrZcLy+yWph+aI6pIj2MdoK3YI8AQ=="],
+
     "@swc/core": ["@swc/core@1.12.11", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.23" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.12.11", "@swc/core-darwin-x64": "1.12.11", "@swc/core-linux-arm-gnueabihf": "1.12.11", "@swc/core-linux-arm64-gnu": "1.12.11", "@swc/core-linux-arm64-musl": "1.12.11", "@swc/core-linux-x64-gnu": "1.12.11", "@swc/core-linux-x64-musl": "1.12.11", "@swc/core-win32-arm64-msvc": "1.12.11", "@swc/core-win32-ia32-msvc": "1.12.11", "@swc/core-win32-x64-msvc": "1.12.11" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-P3GM+0lqjFctcp5HhR9mOcvLSX3SptI9L1aux0Fuvgt8oH4f92rCUrkodAa0U2ktmdjcyIiG37xg2mb/dSCYSA=="],
 
     "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.12.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-J19Jj9Y5x/N0loExH7W0OI9OwwoVyxutDdkyq1o/kgXyBqmmzV7Y/Q9QekI2Fm/qc5mNeAdP7aj4boY4AY/JPw=="],
@@ -194,19 +214,29 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@24.0.10", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA=="],
-
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@18.3.23", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.6.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.19", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "browserslist": ["browserslist@4.25.1", "", { "dependencies": { "caniuse-lite": "^1.0.30001726", "electron-to-chromium": "^1.5.173", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": "cli.js" }, "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001727", "", {}, "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -214,15 +244,27 @@
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
+    "dedent-js": ["dedent-js@1.0.1", "", {}, "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="],
+
+    "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.180", "", {}, "sha512-ED+GEyEh3kYMwt2faNmgMB0b8O5qtATGgR4RmRsIp4T6p7B8vdMbIedYndnvZfsaXvSzegtpfqRMDNCjjiSduA=="],
 
-    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.2.9", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -230,9 +272,15 @@
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -242,36 +290,52 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
-
-    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
-
-    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
     "rollup": ["rollup@4.44.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.44.2", "@rollup/rollup-android-arm64": "4.44.2", "@rollup/rollup-darwin-arm64": "4.44.2", "@rollup/rollup-darwin-x64": "4.44.2", "@rollup/rollup-freebsd-arm64": "4.44.2", "@rollup/rollup-freebsd-x64": "4.44.2", "@rollup/rollup-linux-arm-gnueabihf": "4.44.2", "@rollup/rollup-linux-arm-musleabihf": "4.44.2", "@rollup/rollup-linux-arm64-gnu": "4.44.2", "@rollup/rollup-linux-arm64-musl": "4.44.2", "@rollup/rollup-linux-loongarch64-gnu": "4.44.2", "@rollup/rollup-linux-powerpc64le-gnu": "4.44.2", "@rollup/rollup-linux-riscv64-gnu": "4.44.2", "@rollup/rollup-linux-riscv64-musl": "4.44.2", "@rollup/rollup-linux-s390x-gnu": "4.44.2", "@rollup/rollup-linux-x64-gnu": "4.44.2", "@rollup/rollup-linux-x64-musl": "4.44.2", "@rollup/rollup-win32-arm64-msvc": "4.44.2", "@rollup/rollup-win32-ia32-msvc": "4.44.2", "@rollup/rollup-win32-x64-msvc": "4.44.2", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg=="],
 
-    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "svelte": ["svelte@5.55.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg=="],
 
-    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
+    "svelte2tsx": ["svelte2tsx@0.7.55", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0 || ^6.0.0" } }, "sha512-JWzgeM3lqySRNfqcsesvVEh8LhTWBxQJ9RMjzJ+VepdmXtVnNd0SbtGctG6+/fbHq0N6mhwSd823gszw9JHeGQ=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "uuid": ["uuid@10.0.0", "", { "bin": "dist/bin/uuid" }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
-    "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": "bin/vite.js" }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-plugin-top-level-await": ["vite-plugin-top-level-await@1.5.0", "", { "dependencies": { "@rollup/plugin-virtual": "^3.0.2", "@swc/core": "^1.10.16", "uuid": "^10.0.0" }, "peerDependencies": { "vite": ">=2.8" } }, "sha512-r/DtuvHrSqUVk23XpG2cl8gjt1aATMG5cjExXL1BUTcSNab6CzkcPua9BPEc9fuTP5UpwClCxUe3+dNGL0yrgQ=="],
 
     "vite-plugin-wasm": ["vite-plugin-wasm@3.5.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7" } }, "sha512-X5VWgCnqiQEGb+omhlBVsvTfxikKtoOgAzQ95+BZ8gQ+VfMHIjSHr0wyvXFQCa0eKQ0fKyaL0kWcEnYqBac4lQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "esrap/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
   }
 }

--- a/core/buffers.ts
+++ b/core/buffers.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared zero-allocation hot-path scratch space.
+ *
+ * Used by every framework adapter (React, Svelte, …) so the optimisation
+ * isn't duplicated. The pools are module-level singletons — adapters take
+ * turns through the `useBufferA` flag stored on each virtualizer instance.
+ */
+
+export const MAX_SAFE_SCROLL_HEIGHT = 15_000_000;
+export const MAX_VISIBLE = 200;
+
+export interface ScratchBuffer {
+  items: Int32Array;
+  offsets: Float64Array;
+  sizes: Float64Array;
+}
+
+export const bufferA: ScratchBuffer = {
+  items: new Int32Array(MAX_VISIBLE),
+  offsets: new Float64Array(MAX_VISIBLE),
+  sizes: new Float64Array(MAX_VISIBLE),
+};
+
+export const bufferB: ScratchBuffer = {
+  items: new Int32Array(MAX_VISIBLE),
+  offsets: new Float64Array(MAX_VISIBLE),
+  sizes: new Float64Array(MAX_VISIBLE),
+};
+
+export const cached = {
+  itemsA: [] as number[],
+  itemsB: [] as number[],
+  offsetsA: [] as number[],
+  offsetsB: [] as number[],
+  sizesA: [] as number[],
+  sizesB: [] as number[],
+};
+
+export interface VirtualRangeSnapshot {
+  startIndex: number;
+  endIndex: number;
+  items: readonly number[];
+  offsets: readonly number[];
+  sizes: readonly number[];
+  totalHeight: number;
+  paddingTop: number;
+  velocity: number;
+}
+
+export const EMPTY_RANGE: VirtualRangeSnapshot = Object.freeze({
+  startIndex: 0,
+  endIndex: 0,
+  items: Object.freeze([]) as readonly number[],
+  offsets: Object.freeze([]) as readonly number[],
+  sizes: Object.freeze([]) as readonly number[],
+  totalHeight: 0,
+  paddingTop: 0,
+  velocity: 0,
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js",
+      "default": "./dist/svelte/index.js"
+    },
     "./wasm/*": "./dist/wasm/*",
     "./package.json": "./package.json"
   },
@@ -53,7 +59,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "bun run build:wasm && bun run copy:wasm && tsc && mkdir -p dist/wasm && cp wasm/warper_wasm.js wasm/warper_wasm.d.ts wasm/warper_wasm_bg.wasm wasm/warper_wasm_bg.wasm.d.ts dist/wasm/",
+    "build": "bun run build:wasm && bun run copy:wasm && tsc && bun run build:svelte && mkdir -p dist/wasm && cp wasm/warper_wasm.js wasm/warper_wasm.d.ts wasm/warper_wasm_bg.wasm wasm/warper_wasm_bg.wasm.d.ts dist/wasm/",
+    "build:svelte": "svelte-package -i ./svelte -o ./dist/svelte --tsconfig ./tsconfig.svelte.json",
     "build:wasm": "cd wasm/rust && wasm-pack build --target web --release && rm -f pkg/.gitignore",
     "copy:wasm": "cp wasm/rust/pkg/warper_wasm.js wasm/rust/pkg/warper_wasm.d.ts wasm/rust/pkg/warper_wasm_bg.wasm wasm/rust/pkg/warper_wasm_bg.wasm.d.ts wasm/",
     "build:examples": "mkdir -p examples-dist && cp examples/index.html examples-dist/ && bun vite build --config examples/list/vite.config.ts --outDir ../../examples-dist/list && bun vite build --config examples/grid/vite.config.ts --outDir ../../examples-dist/grid && bun vite build --config examples/one-million-rows/vite.config.ts --outDir ../../examples-dist/one-million-rows && bun vite build --config examples/chat/vite.config.ts --outDir ../../examples-dist/chat && bun vite build --config examples/tree/vite.config.ts --outDir ../../examples-dist/tree",
@@ -69,12 +76,21 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "svelte": "^5.29.0"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "react-dom": { "optional": true },
+    "svelte": { "optional": true }
   },
   "devDependencies": {
+    "@sveltejs/package": "^2.3.7",
     "@types/react": "^18.2.66 || ^19.0.0",
     "@types/react-dom": "^18.2.22 || ^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "svelte": "^5.29.0",
+    "svelte2tsx": "^0.7.0",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",
     "vite-plugin-top-level-await": "^1.5.0",

--- a/react/hooks/useVirtualizer.ts
+++ b/react/hooks/useVirtualizer.ts
@@ -25,28 +25,28 @@
 
 import { useRef, useEffect, useCallback, useState } from 'react';
 import { VirtualizerOptions } from '../../types';
-import { 
-  initializeWasm, 
+import {
+  initializeWasm,
   createVirtualizer,
   createUniformVirtualizer,
   QuantumVariable,
   QuantumUniform,
 } from '../../core/wasm';
+import {
+  MAX_SAFE_SCROLL_HEIGHT,
+  MAX_VISIBLE,
+  bufferA,
+  bufferB,
+  cached,
+  EMPTY_RANGE,
+  type VirtualRangeSnapshot,
+} from '../../core/buffers';
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export interface VirtualRange {
-  startIndex: number;
-  endIndex: number;
-  items: readonly number[];
-  offsets: readonly number[];
-  sizes: readonly number[];
-  totalHeight: number;
-  paddingTop: number;
-  velocity: number;
-}
+export type VirtualRange = VirtualRangeSnapshot;
 
 export interface UseVirtualizerResult<TElement extends HTMLElement> {
   scrollElementRef: React.RefCallback<TElement>;
@@ -57,45 +57,6 @@ export interface UseVirtualizerResult<TElement extends HTMLElement> {
   scrollToIndex: (index: number, behavior?: ScrollBehavior) => void;
   totalHeight: number;
 }
-
-// ============================================================================
-// CONSTANTS
-// ============================================================================
-
-const MAX_SAFE_SCROLL_HEIGHT = 15_000_000;
-const MAX_VISIBLE = 200;
-
-// Double-buffered TypedArrays for zero-allocation hot path
-// Using TypedArrays allows subarray() which creates views without copying
-const bufferA = {
-  items: new Int32Array(MAX_VISIBLE),
-  offsets: new Float64Array(MAX_VISIBLE),
-  sizes: new Float64Array(MAX_VISIBLE),
-};
-const bufferB = {
-  items: new Int32Array(MAX_VISIBLE),
-  offsets: new Float64Array(MAX_VISIBLE),
-  sizes: new Float64Array(MAX_VISIBLE),
-};
-
-// Reusable array views to avoid allocation - will be populated from TypedArrays
-let cachedItemsA: number[] = [];
-let cachedItemsB: number[] = [];
-let cachedOffsetsA: number[] = [];
-let cachedOffsetsB: number[] = [];
-let cachedSizesA: number[] = [];
-let cachedSizesB: number[] = [];
-
-const EMPTY_RANGE: VirtualRange = Object.freeze({
-  startIndex: 0,
-  endIndex: 0,
-  items: Object.freeze([]) as readonly number[],
-  offsets: Object.freeze([]) as readonly number[],
-  sizes: Object.freeze([]) as readonly number[],
-  totalHeight: 0,
-  paddingTop: 0,
-  velocity: 0,
-});
 
 // ============================================================================
 // Main Hook
@@ -238,23 +199,23 @@ export function useVirtualizer<T, TElement extends HTMLElement = HTMLDivElement>
 
     // Zero-allocation: reuse cached arrays and update their contents
     // This avoids creating new arrays on every frame
-    let cachedItems = useA ? cachedItemsA : cachedItemsB;
-    let cachedOffsets = useA ? cachedOffsetsA : cachedOffsetsB;
-    let cachedSizes = useA ? cachedSizesA : cachedSizesB;
-    
+    let cachedItems = useA ? cached.itemsA : cached.itemsB;
+    let cachedOffsets = useA ? cached.offsetsA : cached.offsetsB;
+    let cachedSizes = useA ? cached.sizesA : cached.sizesB;
+
     // Resize cached arrays only if needed (rare)
     if (cachedItems.length !== count) {
       cachedItems = new Array(count);
       cachedOffsets = new Array(count);
       cachedSizes = new Array(count);
       if (useA) {
-        cachedItemsA = cachedItems;
-        cachedOffsetsA = cachedOffsets;
-        cachedSizesA = cachedSizes;
+        cached.itemsA = cachedItems;
+        cached.offsetsA = cachedOffsets;
+        cached.sizesA = cachedSizes;
       } else {
-        cachedItemsB = cachedItems;
-        cachedOffsetsB = cachedOffsets;
-        cachedSizesB = cachedSizes;
+        cached.itemsB = cachedItems;
+        cached.offsetsB = cachedOffsets;
+        cached.sizesB = cachedSizes;
       }
     }
     

--- a/svelte/components/Warper.svelte
+++ b/svelte/components/Warper.svelte
@@ -1,0 +1,119 @@
+<script lang="ts" generics="T">
+  import type { Snippet } from 'svelte';
+  import type { VirtualizerOptions } from '../../types/core';
+  import { createVirtualizer } from '../hooks/createVirtualizer.svelte';
+
+  interface Props extends VirtualizerOptions<T> {
+    children: Snippet<[index: number]>;
+    loadingPlaceholder?: Snippet;
+    errorPlaceholder?: Snippet<[error: Error]>;
+    onRendered?: () => void;
+    class?: string;
+    style?: string;
+  }
+
+  let {
+    itemCount,
+    estimateSize,
+    overscan = 3,
+    height,
+    horizontal = false,
+    children,
+    loadingPlaceholder,
+    errorPlaceholder,
+    onRendered,
+    class: className = '',
+    style = '',
+  }: Props = $props();
+
+  const v = createVirtualizer<T>(() => ({
+    itemCount,
+    estimateSize,
+    overscan,
+    horizontal,
+  }));
+
+  // Exposed via `bind:this` so consumers can imperatively scroll.
+  export function scrollToOffset(offset: number, behavior: ScrollBehavior = 'auto') {
+    v.scrollToOffset(offset, behavior);
+  }
+  export function scrollToIndex(index: number, behavior: ScrollBehavior = 'auto') {
+    v.scrollToIndex(index, behavior);
+  }
+
+  let firedRendered = false;
+  $effect(() => {
+    if (!v.isLoading && onRendered && !firedRendered) {
+      firedRendered = true;
+      onRendered();
+    }
+  });
+
+  const containerHeight = $derived(typeof height === 'number' ? `${height}px` : (height ?? '100%'));
+
+  const CONTAINER_STATIC =
+    'width:100%; overflow:auto; position:relative; overscroll-behavior:contain; contain:strict;';
+  const INNER_STATIC = 'width:100%; position:relative; pointer-events:none;';
+  const VIEWPORT_STATIC = 'position:absolute; top:0; left:0; width:100%; will-change:transform;';
+  const ROW_STATIC =
+    'position:absolute; top:0; left:0; width:100%; contain:layout style paint; will-change:transform;';
+</script>
+
+{#if v.error}
+  <div
+    {@attach v.scrollElement}
+    class={className}
+    style={CONTAINER_STATIC + style}
+    style:height={containerHeight}
+  >
+    {#if errorPlaceholder}
+      {@render errorPlaceholder(v.error)}
+    {:else}
+      <div style="padding:20px; color:#ef4444;">Error: {v.error.message}</div>
+    {/if}
+  </div>
+{:else if v.isLoading}
+  <div
+    {@attach v.scrollElement}
+    class={className}
+    style={CONTAINER_STATIC + style}
+    style:height={containerHeight}
+  >
+    {#if loadingPlaceholder}
+      {@render loadingPlaceholder()}
+    {:else}
+      <div style="padding:20px; color:#888;">Loading…</div>
+    {/if}
+  </div>
+{:else}
+  <div
+    {@attach v.scrollElement}
+    class={className}
+    data-warper-container
+    style={CONTAINER_STATIC + style}
+    style:height={containerHeight}
+  >
+    <div
+      data-warper-inner
+      style={INNER_STATIC}
+      style:height="{v.range.totalHeight || 1}px"
+    >
+      <div
+        data-warper-viewport
+        style={VIEWPORT_STATIC}
+        style:transform="translateY({v.range.paddingTop}px)"
+      >
+        {#each v.range.items as itemIndex, i (itemIndex)}
+          <div
+            data-index={itemIndex}
+            style={ROW_STATIC}
+            style:transform="translateY({v.range.offsets[i]}px)"
+            style:height="{v.range.sizes[i]}px"
+          >
+            {@render children(itemIndex)}
+          </div>
+        {/each}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/svelte/hooks/createVirtualizer.svelte.ts
+++ b/svelte/hooks/createVirtualizer.svelte.ts
@@ -1,0 +1,386 @@
+/**
+ * Svelte 5 virtualizer hook — port of react/hooks/useVirtualizer.ts.
+ *
+ * Uses the latest Svelte 5 runes:
+ * - $state.raw for the `range` object (TypedArray-backed views reassigned
+ *   wholesale — proxy overhead would be pure waste)
+ * - $state for scalar isLoading / error
+ * - $effect for lifecycle + cleanup
+ * - @attach attachments (Svelte 5.29+) for the scroll container
+ *
+ * Reuses core/buffers.ts so the zero-allocation hot path is shared with
+ * the React adapter.
+ */
+
+import type { Attachment } from 'svelte/attachments';
+import { on } from 'svelte/events';
+import type { VirtualizerOptions } from '../../types/core';
+import {
+  initializeWasm,
+  createVirtualizer as createWasmVirtualizer,
+  createUniformVirtualizer,
+  type QuantumVariable,
+  type QuantumUniform,
+} from '../../core/wasm';
+import {
+  MAX_SAFE_SCROLL_HEIGHT,
+  MAX_VISIBLE,
+  bufferA,
+  bufferB,
+  cached,
+  EMPTY_RANGE,
+  type VirtualRangeSnapshot,
+} from '../../core/buffers';
+
+export type VirtualRange = VirtualRangeSnapshot;
+
+export interface CreateVirtualizerResult {
+  /** Attach to the scroll container via `{@attach scrollElement}` */
+  scrollElement: Attachment<HTMLElement>;
+  readonly range: VirtualRange;
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+  readonly totalHeight: number;
+  scrollToOffset: (offset: number, behavior?: ScrollBehavior) => void;
+  scrollToIndex: (index: number, behavior?: ScrollBehavior) => void;
+}
+
+/**
+ * Create a Warper virtualizer. Pass options as a getter so reactivity
+ * crosses the function boundary:
+ *
+ *     const v = createVirtualizer(() => ({ itemCount, estimateSize }));
+ *
+ * Must be called from a component `<script>` (or any tracking context).
+ * For non-component usage, wrap in `$effect.root`.
+ */
+export function createVirtualizer<T>(
+  getOptions: () => VirtualizerOptions<T>
+): CreateVirtualizerResult {
+  let range = $state.raw<VirtualRange>(EMPTY_RANGE);
+  let isLoading = $state(true);
+  let error = $state<Error | null>(null);
+
+  const r = {
+    element: null as HTMLElement | null,
+    virtualizer: null as QuantumVariable | null,
+    uniformVirtualizer: null as QuantumUniform | null,
+    isUniform: false,
+    uniformSize: 0,
+    lastStart: -1,
+    lastEnd: -1,
+    lastPaddingTop: 0,
+    rafId: 0,
+    rafPending: false,
+    mounted: true,
+    itemCount: 0,
+    estimateSize: ((_: number) => 0) as (i: number) => number,
+    overscan: 3,
+    horizontal: false,
+    scrollMultiplier: 1,
+    virtualTotalHeight: 0,
+    actualScrollHeight: 0,
+    useBufferA: true,
+    lastScrollTime: 0,
+    lastScrollPos: 0,
+    velocity: 0,
+    initialized: false,
+  };
+
+  function readOptions(): void {
+    const o = getOptions();
+    r.itemCount = o.itemCount;
+    r.estimateSize = o.estimateSize;
+    r.overscan = o.overscan ?? 3;
+    r.horizontal = o.horizontal ?? false;
+  }
+
+  function recomputeScrollMetrics(virtualTotalHeight: number): void {
+    r.virtualTotalHeight = virtualTotalHeight;
+    if (virtualTotalHeight > MAX_SAFE_SCROLL_HEIGHT) {
+      r.actualScrollHeight = MAX_SAFE_SCROLL_HEIGHT;
+      r.scrollMultiplier = virtualTotalHeight / MAX_SAFE_SCROLL_HEIGHT;
+    } else {
+      r.actualScrollHeight = virtualTotalHeight;
+      r.scrollMultiplier = 1;
+    }
+  }
+
+  function buildVirtualizer(): void {
+    const count = r.itemCount;
+    const firstSize = r.estimateSize(0);
+
+    let isUniform = true;
+    const checkCount = Math.min(10, count);
+    for (let i = 1; i < checkCount; i++) {
+      if (r.estimateSize(i) !== firstSize) {
+        isUniform = false;
+        break;
+      }
+    }
+
+    r.isUniform = isUniform;
+    r.uniformSize = firstSize;
+
+    let virtualTotalHeight: number;
+    if (isUniform) {
+      r.uniformVirtualizer = createUniformVirtualizer(count, firstSize);
+      virtualTotalHeight = count * firstSize;
+    } else {
+      const sizes = new Array(count);
+      for (let i = 0; i < count; i++) sizes[i] = r.estimateSize(i);
+      r.virtualizer = createWasmVirtualizer(sizes);
+      virtualTotalHeight = sizes.reduce((a, b) => a + b, 0);
+    }
+
+    recomputeScrollMetrics(virtualTotalHeight);
+  }
+
+  function resizeVirtualizer(): void {
+    const count = r.itemCount;
+    let virtualTotalHeight: number;
+
+    if (r.isUniform && r.uniformVirtualizer) {
+      r.uniformVirtualizer.set_count(count);
+      virtualTotalHeight = count * r.uniformSize;
+    } else if (r.virtualizer) {
+      const sizes = new Array(count);
+      for (let i = 0; i < count; i++) sizes[i] = r.estimateSize(i);
+      r.virtualizer.free();
+      r.virtualizer = createWasmVirtualizer(sizes);
+      virtualTotalHeight = sizes.reduce((a, b) => a + b, 0);
+    } else {
+      return;
+    }
+
+    recomputeScrollMetrics(virtualTotalHeight);
+    r.lastStart = -1;
+    r.lastEnd = -1;
+  }
+
+  function calculateRange(): void {
+    const el = r.element;
+    if (!el || !r.mounted) return;
+
+    const scrollPos = r.horizontal ? el.scrollLeft : el.scrollTop;
+    const viewportSize = r.horizontal ? el.clientWidth : el.clientHeight;
+    if (viewportSize <= 0) return;
+
+    const now = performance.now();
+    const dt = now - r.lastScrollTime;
+    if (dt > 0 && dt < 100) {
+      r.velocity = Math.abs((scrollPos - r.lastScrollPos) / dt) * 1000;
+    }
+    r.lastScrollTime = now;
+    r.lastScrollPos = scrollPos;
+
+    const virtualScroll = scrollPos * r.scrollMultiplier;
+
+    let start = 0;
+    let end = 0;
+    if (r.isUniform && r.uniformVirtualizer) {
+      const info = r.uniformVirtualizer.calc_range(virtualScroll, viewportSize, r.overscan);
+      start = info[0] | 0;
+      end = info[1] | 0;
+    } else if (r.virtualizer) {
+      const info = r.virtualizer.calc_range(virtualScroll, viewportSize, r.overscan);
+      start = info[0] | 0;
+      end = info[1] | 0;
+    } else {
+      return;
+    }
+
+    start = Math.max(0, start);
+    end = Math.min(r.itemCount, end);
+
+    let firstItemVirtualOffset = 0;
+    if (r.isUniform) {
+      firstItemVirtualOffset = start * r.uniformSize;
+    } else if (r.virtualizer) {
+      firstItemVirtualOffset = r.virtualizer.get_offset(start);
+    }
+
+    const paddingTop = firstItemVirtualOffset / r.scrollMultiplier;
+
+    if (
+      start === r.lastStart &&
+      end === r.lastEnd &&
+      Math.abs(paddingTop - r.lastPaddingTop) < 0.5
+    ) {
+      return;
+    }
+
+    r.lastStart = start;
+    r.lastEnd = end;
+    r.lastPaddingTop = paddingTop;
+
+    const count = Math.min(end - start, MAX_VISIBLE);
+    const useA = r.useBufferA;
+    const buffer = useA ? bufferA : bufferB;
+    r.useBufferA = !r.useBufferA;
+
+    if (r.isUniform) {
+      const size = r.uniformSize;
+      for (let i = 0; i < count; i++) {
+        const idx = start + i;
+        buffer.items[i] = idx;
+        buffer.offsets[i] = i * size;
+        buffer.sizes[i] = size;
+      }
+    } else if (r.virtualizer) {
+      for (let i = 0; i < count; i++) {
+        const idx = start + i;
+        buffer.items[i] = idx;
+        buffer.offsets[i] = r.virtualizer.get_offset(idx) - firstItemVirtualOffset;
+        buffer.sizes[i] = r.virtualizer.get_size(idx);
+      }
+    }
+
+    let cachedItems = useA ? cached.itemsA : cached.itemsB;
+    let cachedOffsets = useA ? cached.offsetsA : cached.offsetsB;
+    let cachedSizes = useA ? cached.sizesA : cached.sizesB;
+
+    if (cachedItems.length !== count) {
+      cachedItems = new Array(count);
+      cachedOffsets = new Array(count);
+      cachedSizes = new Array(count);
+      if (useA) {
+        cached.itemsA = cachedItems;
+        cached.offsetsA = cachedOffsets;
+        cached.sizesA = cachedSizes;
+      } else {
+        cached.itemsB = cachedItems;
+        cached.offsetsB = cachedOffsets;
+        cached.sizesB = cachedSizes;
+      }
+    }
+
+    for (let i = 0; i < count; i++) {
+      cachedItems[i] = buffer.items[i];
+      cachedOffsets[i] = buffer.offsets[i];
+      cachedSizes[i] = buffer.sizes[i];
+    }
+
+    range = {
+      startIndex: start,
+      endIndex: end,
+      items: cachedItems as readonly number[],
+      offsets: cachedOffsets as readonly number[],
+      sizes: cachedSizes as readonly number[],
+      totalHeight: r.actualScrollHeight,
+      paddingTop,
+      velocity: r.velocity,
+    };
+  }
+
+  function handleScroll(): void {
+    if (r.rafPending) return;
+    r.rafPending = true;
+    r.rafId = requestAnimationFrame(() => {
+      r.rafPending = false;
+      calculateRange();
+    });
+  }
+
+  // Populate r.itemCount / r.estimateSize before WASM init runs.
+  readOptions();
+
+  // One-time initialisation: load WASM, build the virtualizer, attach cleanup.
+  $effect(() => {
+    r.mounted = true;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await initializeWasm();
+        if (cancelled || !r.mounted) return;
+        buildVirtualizer();
+        r.initialized = true;
+        isLoading = false;
+        if (r.element) {
+          requestAnimationFrame(() => {
+            if (r.mounted) calculateRange();
+          });
+        }
+      } catch (err) {
+        if (cancelled || !r.mounted) return;
+        error = err instanceof Error ? err : new Error(String(err));
+        isLoading = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      r.mounted = false;
+      if (r.rafId) cancelAnimationFrame(r.rafId);
+      r.virtualizer?.free();
+      r.uniformVirtualizer?.free();
+      r.virtualizer = null;
+      r.uniformVirtualizer = null;
+    };
+  });
+
+  // React to option changes (itemCount / estimateSize / overscan / horizontal).
+  // Calling `getOptions()` inside the effect performs reactive reads on the
+  // consumer-side state, registering them as dependencies of this effect.
+  $effect(() => {
+    getOptions();
+    if (!r.initialized) return;
+    readOptions();
+    resizeVirtualizer();
+    calculateRange();
+  });
+
+  const scrollElement: Attachment<HTMLElement> = (node) => {
+    r.element = node;
+    const off = on(node, 'scroll', handleScroll, { passive: true });
+    if (r.initialized) {
+      requestAnimationFrame(() => {
+        if (r.mounted) calculateRange();
+      });
+    }
+    return () => {
+      off();
+      if (r.element === node) r.element = null;
+    };
+  };
+
+  function scrollToOffset(offset: number, behavior: ScrollBehavior = 'auto'): void {
+    const el = r.element;
+    if (!el) return;
+    const actualOffset = offset / r.scrollMultiplier;
+    if (r.horizontal) {
+      el.scrollTo({ left: actualOffset, behavior });
+    } else {
+      el.scrollTo({ top: actualOffset, behavior });
+    }
+  }
+
+  function scrollToIndex(index: number, behavior: ScrollBehavior = 'auto'): void {
+    let virtualOffset = 0;
+    if (r.isUniform) {
+      virtualOffset = index * r.uniformSize;
+    } else if (r.virtualizer) {
+      virtualOffset = r.virtualizer.get_offset(index);
+    }
+    scrollToOffset(virtualOffset, behavior);
+  }
+
+  return {
+    scrollElement,
+    get range() {
+      return range;
+    },
+    get isLoading() {
+      return isLoading;
+    },
+    get error() {
+      return error;
+    },
+    get totalHeight() {
+      return range.totalHeight;
+    },
+    scrollToOffset,
+    scrollToIndex,
+  };
+}

--- a/svelte/index.ts
+++ b/svelte/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Warper — Svelte 5 adapter entry point.
+ *
+ * Subpath export: `@itsmeadarsh/warper/svelte`
+ *
+ * No React imports in this module graph — React stays an optional peer
+ * for the main entry only.
+ */
+
+export { createVirtualizer } from './hooks/createVirtualizer.svelte';
+export type {
+  VirtualRange,
+  CreateVirtualizerResult,
+} from './hooks/createVirtualizer.svelte';
+
+export { default as Warper } from './components/Warper.svelte';
+
+export type { VirtualizerOptions, VirtualItem } from '../types/core';
+
+// Logging passthrough (framework-agnostic).
+export { setLogging, isLoggingEnabled } from '../core/wasm';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
     "examples",
     "examples-dist",
     "dist",
+    "svelte",
     "vite.config.ts",
     "*.config.ts"
   ]

--- a/tsconfig.svelte.json
+++ b/tsconfig.svelte.json
@@ -1,0 +1,29 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/svelte",
+    "types": ["svelte"]
+  },
+  "include": [
+    "svelte/**/*.ts",
+    "svelte/**/*.svelte",
+    "svelte/**/*.svelte.ts",
+    "core/**/*.ts",
+    "types/core.ts",
+    "wasm/rust/pkg/warper_wasm.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "examples",
+    "examples-dist",
+    "benchmark",
+    "react",
+    "types/react.ts",
+    "types/index.ts"
+  ]
+}

--- a/types/core.ts
+++ b/types/core.ts
@@ -1,0 +1,29 @@
+/**
+ * Framework-agnostic Warper types — safe to import from any adapter
+ * (React, Svelte, Vue, …) without pulling in framework dependencies.
+ */
+
+export interface VirtualItem {
+  index: number;
+  offset_top: number;
+  size: number;
+}
+
+export interface VirtualizerOptions<T> {
+  /** Total number of items */
+  itemCount: number;
+  /** Function to estimate size for an item at index */
+  estimateSize: (index: number) => number;
+  /** Optional data array */
+  data?: T[];
+  /** Number of items to render outside visible area (default: 3) */
+  overscan?: number;
+  /** Fixed height of the container (optional, defaults to 100%) */
+  height?: number;
+  /** Initial scroll position */
+  scrollTop?: number;
+  /** Function to measure actual element size */
+  measureElement?: (element: HTMLElement) => number;
+  /** Enable horizontal mode */
+  horizontal?: boolean;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,60 +1,7 @@
-import React from 'react';
-
 /**
- * Represents a single virtual item from WASM
+ * Re-export hub. Framework-agnostic types live in ./core; React-specific types in ./react.
+ * The Svelte adapter imports directly from ./core to avoid pulling React into its graph.
  */
-export interface VirtualItem {
-  index: number;
-  offset_top: number;
-  size: number;
-}
 
-/**
- * Display item with styling for rendering
- */
-export interface DisplayItem {
-  index: number;
-  style: React.CSSProperties;
-  measureElement?: (element: HTMLElement | null) => void;
-}
-
-/**
- * Options for the virtualizer hook
- */
-export interface VirtualizerOptions<T> {
-  /** Total number of items */
-  itemCount: number;
-  /** Function to estimate size for an item at index */
-  estimateSize: (index: number) => number;
-  /** Optional data array */
-  data?: T[];
-  /** Number of items to render outside visible area (default: 3) */
-  overscan?: number;
-  /** Fixed height of the container (optional, defaults to 100%) */
-  height?: number;
-  /** Initial scroll position */
-  scrollTop?: number;
-  /** Function to measure actual element size */
-  measureElement?: (element: HTMLElement) => number;
-  /** Enable horizontal mode */
-  horizontal?: boolean;
-}
-
-/**
- * Props for WarperComponent
- */
-export interface WarperComponentProps<T> extends VirtualizerOptions<T> {
-  /** Render function for each item */
-  children: (index: number, style: React.CSSProperties) => React.ReactNode;
-  /** Called when items have been rendered */
-  onRendered?: () => void;
-  /** Placeholder while loading */
-  loadingPlaceholder?: React.ReactNode;
-  /** Placeholder for errors */
-  errorPlaceholder?: (error: Error) => React.ReactNode;
-  /** Additional class name */
-  className?: string;
-  /** Additional styles */
-  style?: React.CSSProperties;
-}
-
+export type { VirtualItem, VirtualizerOptions } from './core';
+export type { DisplayItem, WarperComponentProps } from './react';

--- a/types/react.ts
+++ b/types/react.ts
@@ -1,0 +1,21 @@
+/**
+ * React-only Warper types. Pulled in only by consumers of the React adapter.
+ */
+
+import React from 'react';
+import type { VirtualizerOptions } from './core';
+
+export interface DisplayItem {
+  index: number;
+  style: React.CSSProperties;
+  measureElement?: (element: HTMLElement | null) => void;
+}
+
+export interface WarperComponentProps<T> extends VirtualizerOptions<T> {
+  children: (index: number, style: React.CSSProperties) => React.ReactNode;
+  onRendered?: () => void;
+  loadingPlaceholder?: React.ReactNode;
+  errorPlaceholder?: (error: Error) => React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}


### PR DESCRIPTION
## Summary

Adds Svelte 5 as a first-class adapter alongside the existing React one, via the subpath export ``@itsmeadarsh/warper/svelte``. The Svelte build does not pull React into its import graph — both ``react`` and ``svelte`` are now optional peer deps.

- New exports: ``createVirtualizer`` (rune-based hook) + ``<Warper>`` ``.svelte`` component, mirroring the React hook + component surface.
- Shared core: the zero-allocation TypedArray buffer pools were extracted out of ``react/hooks/useVirtualizer.ts`` into ``core/buffers.ts`` so both adapters reuse the same hot-path scratch space.
- Types split: ``types/core.ts`` is framework-agnostic; ``types/react.ts`` holds the React-only types. ``types/index.ts`` re-exports both, so existing React imports are unchanged.
- Build: new ``build:svelte`` script runs ``@sveltejs/package`` with a dedicated ``tsconfig.svelte.json``, emitting ``dist/svelte/`` with ``.svelte.d.ts`` types.
- ``.svelte-kit/`` (scratch dir from ``svelte-package``) is gitignored.

## Idiomatic Svelte 5 choices (verified against svelte.dev docs)

- ``$state.raw`` for the ``range`` object — TypedArray-backed views are reassigned wholesale, so deep proxy reactivity would be pure overhead.
- ``@attach`` attachments (Svelte 5.29+) instead of ``use:`` actions for the scroll container.
- ``on()`` from ``svelte/events`` for the scroll listener.
- ``style:`` directives for dynamic style values (height / transform); static styles stay in a single ``style`` attribute.
- Typed ``Snippet<[number]>`` children; ``{@render children(itemIndex)}``.
- Plain ``$effect`` for lifecycle (consumers needing non-component usage can wrap in ``$effect.root``).

## Test plan

- [ ] ``bun install`` succeeds; no React-related warnings in a Svelte-only consumer environment.
- [ ] ``bun run build`` produces ``dist/svelte/index.js``, ``components/Warper.svelte``, ``hooks/createVirtualizer.svelte.js`` plus matching ``.d.ts`` files.
- [ ] React entrypoint (``@itsmeadarsh/warper``) still builds and the existing examples (``bun run example:list`` etc.) still run.
- [ ] Smoke test in a SvelteKit / Vite-Svelte playground: import ``{ Warper, createVirtualizer }`` from ``@itsmeadarsh/warper/svelte``, render 1M rows, verify scroll, ``range.items`` updates, ``scrollToIndex`` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)